### PR TITLE
fix(router): added vercel.json file with router rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/:path*", "destination": "/index.html" }]
+}


### PR DESCRIPTION
When deployed on Vercel routers don't work, this is an attempt to fix this by adding a vercel.json file following this instruction on Vue Router docs: [Different history modes](https://router.vuejs.org/guide/essentials/history-mode.html#vercel)