### PR TITLE
fix(Charts): :bug: DashboardView responsive

### DIFF
--- a/src/components/AreaChart.vue
+++ b/src/components/AreaChart.vue
@@ -187,5 +187,9 @@ function updateChartTimeline(timeline: string) {
   .toolbar #year_to_date {
     display: none;
   }
+  .toolbar .v-btn--size-default {
+    padding: 0 0.1rem;
+    min-width: 50px;
+  }
 }
 </style>

--- a/src/components/AreaChart.vue
+++ b/src/components/AreaChart.vue
@@ -176,4 +176,16 @@ function updateChartTimeline(timeline: string) {
 .v-tooltip.v-overlay > .v-overlay__content {
   background-color: #111013;
 }
+
+@media (max-width: 768px) {
+  .toolbar {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 425px) {
+  .toolbar #year_to_date {
+    display: none;
+  }
+}
 </style>

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -258,6 +258,7 @@ const orders = lastOrders.orders as IOrderItem[]
     grid-template-columns: 1fr 1fr;
     gap: 2rem;
   }
+
   .card {
     flex-direction: column;
     text-align: center;

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -247,6 +247,12 @@ const orders = lastOrders.orders as IOrderItem[]
   color: red;
 }
 
+@media (max-width: 900px) {
+  .charts {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
   .cards {
     grid-template-columns: 1fr 1fr;
@@ -255,9 +261,6 @@ const orders = lastOrders.orders as IOrderItem[]
   .card {
     flex-direction: column;
     text-align: center;
-  }
-  .charts {
-    grid-template-columns: 1fr;
   }
 
   .charts > .charts__dashboard {

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -81,7 +81,9 @@ const orders = lastOrders.orders as IOrderItem[]
             <p>Current Month Sales</p>
           </div>
         </div>
-        <AreaChart :series="series"></AreaChart>
+        <div class="charts__dashboard__chart">
+          <AreaChart :series="series"></AreaChart>
+        </div>
       </div>
       <div class="charts__donut">
         <h2>Analytics</h2>
@@ -260,6 +262,10 @@ const orders = lastOrders.orders as IOrderItem[]
 
   .charts > .charts__dashboard {
     grid-template-columns: 1fr;
+  }
+
+  .charts__dashboard__chart {
+    padding: 4px 0px;
   }
 
   .charts__dashboard__text {


### PR DESCRIPTION
## Resumen del Bug
En mobile el gráfico de área ocupaba mas espacio de lo que debía y se generaba un scroll horizontal no deseado tanto en ese componente como en el componente de Analitycs.

## Descripción del Problema
El componente AreaChart ocupaba mas del 100% del width, detecte que el problema era el toolbar y el grafico solo se adaptaba ocupando de mas y el grafico de Analitycs tambien se adaptaba al width disponible que se generaba. 

## Solución Propuesta
Decidi ocultar el boton YTD (Year To Date) en mobile para que no genere este desborde del elemento y el problema se soluciono. Ademas se agrego un padding vertical al chart para que se vea correctamente

## Cambios Realizados

- Modificado componente AreaChart
- Modificado componente DashboardView

## Comprobación de Calidad

- [ ] Se han añadido pruebas unitarias relevantes.
- [ ] Se han ejecutado todas las pruebas existentes.
- [ ] Otros: _(especificar)_

## Resultados de las Pruebas
![responsive corregido](https://github.com/manuel-salvador/cenius/assets/85590962/eea3a818-09c7-44fb-b8ae-c5e0b12eec41)

## Revisores Asignados

@saracast909 
@brayanlaiton0116 
